### PR TITLE
default to empty string when extracting URLs

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -7,7 +7,7 @@ var normalizeURL = require('normalize-url');
  * @return {Array} list of URLs
  */
 function extractURLs(string) {
-  var URLs = string.match(URLRegex());
+  var URLs = (string || '').match(URLRegex());
 
   if (URLs) {
     return URLs.map(function(url) {


### PR DESCRIPTION
otherwise null GitHub pull request body values cause an error