### PR TITLE
clarify github token scopes earlier in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ reviewers:
   your_github_username: {}
 ```
 
+In order to use Pull Review as a Hubot plugin or in server mode, you'll need a [GitHub token](https://github.com/settings/tokens). The token must have `repo`, `public_repo`, `read:user`, and `read:org` scopes.
+
 For details on configuration options, check out the [configuration](#configuration) section.
 
 ### GitHub
@@ -289,7 +291,7 @@ An array of pull request labels that are forbidden from pull request review.
 
 ### Environment variables
 
-* `PULL_REVIEW_GITHUB_TOKEN`: GitHub token used to fetch pull request information. The token must have `repo`, `user`, `read:org`, and `read:discussion` scopes. **Required** when using Pull Review as a Hubot plugin or when running in server mode.
+* `PULL_REVIEW_GITHUB_TOKEN`: GitHub token used to fetch pull request information.
 * `PULL_REVIEW_CONFIG_PATH`: location of the config file in the pull request repo (default is `.pull-review`).
 * `PULL_REVIEW_CONFIG`: Pull Review configuration override in JSON/YAML format.
 * `PULL_REVIEW_REQUIRED_ROOMS`: whitelist of Hubot chat rooms for Pull Review requests (e.g. `dev,ops`).


### PR DESCRIPTION
fix #93